### PR TITLE
Example Deck and AllCards.json changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 test.png
 page_*.png
+AllCards.json

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Our goal was to have something in the middle, a card that looked and felt famili
 The project accepts deck lists in the form of CSV's. It ignores the top line and assumes the first two columns are Quantity and Card Name respectively.
 
 ## Getting Started
-Basically, all that is required to run is [Python 3.6](https://www.python.org/) (Yes, actually 3.6 or newer; 3.5 will not work.) and [PyCairo](https://cairographics.org/pycairo/). Depending on how you may use Python for other things, there are a few options for getting those installed. The instructions below are intended to be as simple as possible.
+Basically, all that is required to run is [Python 3.6](https://www.python.org/) (Yes, actually 3.6 or newer; 3.5 will not work.) and [PyCairo](https://cairographics.org/pycairo/). Depending on how you may use Python for other things, there are a few options for getting those installed. The instructions below are intended to be as simple as possible.  
+#### Note on AllCards.json:
+Since starting this project, the team at mtgjson has been very busy (and a lot of cards have been released). As such, the size of the AllCards.json file has balooned large enough for GitHub to be angry about it. Please download the file directly from [their website](https://mtgjson.com/downloads/all-files/) and place it in the same directory as `main.py`
 
 ### Windows
 - Download and install Python 3 using [the installer](https://www.python.org/downloads/windows/)

--- a/example_deck.csv
+++ b/example_deck.csv
@@ -1,0 +1,21 @@
+Qty,Name
+4,Chain Lightning
+4,Curse of the Pierced Heart
+3,Fireblast
+3,Flame Rift
+2,Forgotten Cave
+4,Ghitu Lavarunner
+4,Lava Spike
+4,Lightning Bolt
+16,Mountain
+4,Needle Drop
+4,Rift Bolt
+3,Searing Blaze
+1,Shard Volley
+4,Skewer the Critics
+2,Electrickery
+4,Keldon Marauders
+2,Martyr of Ashes
+2,Molten Rain
+2,Red Elemental Blast
+3,Smash to Smithereens


### PR DESCRIPTION
- Added an example .csv file
- Originally added new AllCards.json but it's now over 50MB to GH got grumpy
- Removed AllCards.json and updated readme to include instructions for downloading it from source